### PR TITLE
config: 라이트모드로 고정

### DIFF
--- a/PicSpot/SceneDelegate.swift
+++ b/PicSpot/SceneDelegate.swift
@@ -22,6 +22,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.windowScene = windowScene
         window?.rootViewController = MainTabBarViewController()
         window?.makeKeyAndVisible()
+        // 라이트모드로 고정
+        // 다크모드에서는 상단 상태바의 글씨가 흰색으로 표시되어 Naver 지도 위에서 글씨가 안보이는 현상이 있음
+        window?.overrideUserInterfaceStyle = .light
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## 개요
인터페이스 스타일을 라이트모드로 고정했습니다 #15 

## 작업사항
- SceneDelegate.swift에서 overrideUserInterfaceStyle을 이용해 라이트모드로 고정했습니다
- ViewController 내부에서 overrideUserInterfaceStyle을 .dark로 설정해도 라이트모드에서 바뀌지 않음을 확인했습니다

## 변경로직(옵션)
- 프로그램 로직이 변경되었을 때만 적어주세요! (에러수정 등등등)
